### PR TITLE
Use @__FILE__ instead of Pkg.dir to get homework.js

### DIFF
--- a/src/Homework.jl
+++ b/src/Homework.jl
@@ -21,9 +21,11 @@ include("library.jl")
 
 function reinit()
 
+    p = joinpath(splitdir(@__FILE__)[1], "homework.js")
+
     # Load javascript into IJulia
     display(MIME"text/html"(),
-        """<script>$(readall(Pkg.dir("Homework", "src", "homework.js")))</script>""")
+        """<script>$(readall(p))</script>""")
 
     # Push some metadata to the Julia side
     comm = Comm(:HomeworkData)


### PR DESCRIPTION
Homework.jl is installed as a default package to `/opt/julia_packages` on JuliaBox.  Since `Pkg.dir` will return `~/.julia/...` we use `@__FILE__` here to get the correct location of homework.js.
